### PR TITLE
NEW: Add tickets for user API endpoint

### DIFF
--- a/app/api/helpdesk/ticket.rb
+++ b/app/api/helpdesk/ticket.rb
@@ -45,10 +45,11 @@ module Api
 
       # ------------------------------------------------------------------------
       # GET /helpdesk/tickets/:filter
-      # By default all
+      # Optional User Id and Filter. Filter default to all.
       # ------------------------------------------------------------------------
-      desc "Gets all helpdesk tickets"
+      desc "Gets all helpdesk tickets. Optional User Id and Resolved filter."
       params do
+        optional :user_id, type: String, desc: "The id of the user to get tickets for."
         optional :filter, type: String, desc: "Filter by resolved, unresolved or all. Defaults to all (unresolved).", default: 'all'
       end
       get '/helpdesk/tickets' do
@@ -56,8 +57,10 @@ module Api
           error!({error: 'Not authorised to get tickets'}, 403)
         end
 
+        user_id = params[:user_id]
         filter = params[:filter] || 'all'
-        filter == 'resolved' ? HelpdeskTicket.all_resolved : HelpdeskTicket.all_unresolved
+        tickets = HelpdeskTicket.all_by_resolved_and_user(filter, user_id)
+        ActiveModel::ArraySerializer.new(tickets, each_serializer: ShallowHelpdeskTicketSerializer)
       end
 
       # ------------------------------------------------------------------------
@@ -75,23 +78,6 @@ module Api
         end
 
         ticket
-      end
-
-      # ------------------------------------------------------------------------
-      # GET /helpdesk/user/tickets/:id
-      # ------------------------------------------------------------------------
-      desc "Gets all helpdesk tickets belonging to user id"
-      params do
-        requires :id, type: Integer, desc: "The id of the user to get all open tickets for"
-      end
-      get '/helpdesk/user/:id/tickets' do
-        user = User.find(params[:id])
-
-        error!({error: 'Not authorised to get ticket details'}, 403) unless user == current_user
-
-        tickets = HelpdeskTicket.where(project_id: Project.where(user_id: params[:id]), is_resolved: false)
-
-        ActiveModel::ArraySerializer.new(tickets, each_serializer: ShallowHelpdeskTicketSerializer)
       end
 
       # ------------------------------------------------------------------------

--- a/app/api/helpdesk/ticket.rb
+++ b/app/api/helpdesk/ticket.rb
@@ -1,4 +1,5 @@
 require 'grape'
+require 'helpdesk_ticket_serializer'
 
 module Api
   module Helpdesk
@@ -74,6 +75,23 @@ module Api
         end
 
         ticket
+      end
+
+      # ------------------------------------------------------------------------
+      # GET /helpdesk/user/tickets/:id
+      # ------------------------------------------------------------------------
+      desc "Gets all helpdesk tickets belonging to user id"
+      params do
+        requires :id, type: Integer, desc: "The id of the user to get all open tickets for"
+      end
+      get '/helpdesk/user/:id/tickets' do
+        user = User.find(params[:id])
+
+        error!({error: 'Not authorised to get ticket details'}, 403) unless user == current_user
+
+        tickets = HelpdeskTicket.where(project_id: Project.where(user_id: params[:id]), is_resolved: false)
+
+        ActiveModel::ArraySerializer.new(tickets, each_serializer: ShallowHelpdeskTicketSerializer)
       end
 
       # ------------------------------------------------------------------------

--- a/app/serializers/helpdesk_ticket_serializer.rb
+++ b/app/serializers/helpdesk_ticket_serializer.rb
@@ -32,10 +32,16 @@ end
 class ShallowHelpdeskTicketSerializer < ActiveModel::Serializer
   attributes :id,
              :project_id,
-             :task_id,
+             :task_definition_id,
              :description,
              :is_resolved,
              :created_at,
              :resolved_at,
              :minutes_to_resolve
+
+  def task_definition_id
+    task = object.task
+    task.task_definition_id if task
+  end
+
 end

--- a/app/serializers/helpdesk_ticket_serializer.rb
+++ b/app/serializers/helpdesk_ticket_serializer.rb
@@ -28,3 +28,14 @@ class HelpdeskTicketSerializer < ActiveModel::Serializer
     object.project.target_grade
   end
 end
+
+class ShallowHelpdeskTicketSerializer < ActiveModel::Serializer
+  attributes :id,
+             :project_id,
+             :task_id,
+             :description,
+             :is_resolved,
+             :created_at,
+             :resolved_at,
+             :minutes_to_resolve
+end

--- a/test/api/helpdesk/ticket_test.rb
+++ b/test/api/helpdesk/ticket_test.rb
@@ -20,6 +20,7 @@ class TicketsTest < ActiveSupport::TestCase
     }
 
     data_to_post = add_auth_token ticket, project.user
+
     post_json "/api/helpdesk/tickets", data_to_post
 
     expected_ticket = HelpdeskTicket.last
@@ -36,6 +37,14 @@ class TicketsTest < ActiveSupport::TestCase
   def test_get_resolved_helpdesk_tickets
     get with_auth_token "/api/helpdesk/tickets?filter=resolved"
     assert_json_equal HelpdeskTicket.all_resolved, last_response_body
+  end
+
+  # GET /helpdesk/user/tickets?
+  def test_get_resolved_helpdesk_tickets
+    id = 1
+    get with_auth_token "/api/helpdesk/user/#{id}/tickets"
+    puts "HERE:::"
+    puts last_response_body
   end
 
   # GET /helpdesk/tickets/:id


### PR DESCRIPTION
This PR adds an endpoint to enable the return of all tickets that belong to a single user. A shallow serialiser has been added for this endpoint to return only relevant data.