### PR TITLE
ENHANCE: Prevents user having >1 open ticket

### DIFF
--- a/app/api/helpdesk/ticket.rb
+++ b/app/api/helpdesk/ticket.rb
@@ -28,9 +28,12 @@ module Api
         project = Project.find(params[:project_id])
         task = params[:task_definition_id].nil? ? nil : task = project.task_for_task_definition(params[:task_definition_id])
 
-
         unless authorise? current_user, project, :create_ticket
           error!({error: "Not authorised to create a ticket for project #{project.id}"}, 403)
+        end
+
+        if HelpdeskTicket.user_has_ticket_open?(project.student.id)
+          error!({error: "Only one ticket may be open at a time for a student"}, 403)
         end
 
         ticket = HelpdeskTicket.create!({

--- a/app/models/helpdesk_ticket.rb
+++ b/app/models/helpdesk_ticket.rb
@@ -54,7 +54,7 @@ class HelpdeskTicket < ActiveRecord::Base
   end
 
   def self.user_has_ticket_open?(user_id)
-    not all_resolved(user_id).empty?
+    not all_unresolved(user_id).empty?
   end
 
   # Returns back all unresolved tickets, optionally limit to a user


### PR DESCRIPTION
This will prevent more than one unresolved ticket being associated with the same Project. The change to the helpdesk_ticket method was needed because I believe the logic was back to front. I have tested in Swagger.